### PR TITLE
Adding coverage for models within app plugins/libraries.

### DIFF
--- a/bin/doctrine-cli-config.php
+++ b/bin/doctrine-cli-config.php
@@ -35,6 +35,18 @@ require_once($appPath . 'config/bootstrap/libraries.php');
 require_once($appPath . 'config/bootstrap/connections.php');
 
 $connection = \lithium\data\Connections::get('default');
+$em = $connection->getEntityManager();
+$config = $em->getConfiguration();
+
+/**
+ * Include models from plugins
+ */
+$libraryModelPaths = glob($appPath . "libraries/*/models");
+if (is_array($libraryModelPaths)) {
+	$existingDrivers = $config->getMetadataDriverImpl();
+	$driverImpl = $config->newDefaultAnnotationDriver($existingDrivers->getPaths() + $libraryModelPaths);
+	$config->setMetadataDriverImpl($driverImpl);
+}
 
 /**
  * Continue with doctrine cli config


### PR DESCRIPTION
Prior to this update, if you have models defined within plugins/libraries, they would not be picked up by the doctrine CLI tool (e.g., orm:schema-tool:create). This update configures the necessary Metadata Drivers so that model classes created within plugins are accounted for.
