### PR TITLE
Fixing typo

### DIFF
--- a/models/BaseEntity.php
+++ b/models/BaseEntity.php
@@ -92,7 +92,7 @@ abstract class BaseEntity extends \lithium\data\Entity implements IModel {
 		if (!$connectionName) {
 			$connectionName = static::getConnectionName();
 		}
-		if (!isset($entityManager[$connectionName])) {
+		if (!isset($entityManagers[$connectionName])) {
 			$connections = static::$_classes['connections'];
 			$entityManagers[$connectionName] = $connections::get($connectionName)->getEntityManager();
 		}


### PR DESCRIPTION
@mariano This PR fixes a typo bug. `$entityManager` (singular) is always undefined, and never cache the EntityManager object reference.
